### PR TITLE
Context menu fix

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -58,11 +58,16 @@ export default class SpreadsheetPlugin extends Plugin {
 
 		this.registerEvent(
 			this.app.workspace.on("file-menu", (menu, file) => {
-				menu.addItem((item) => {
-				  item.setTitle("New spreadsheet").setIcon("document").onClick(function(){
-					 create_new_file(app, file.path, 0 )
-				  });
-				});
+				// Jaedon's Fix
+				// Check if the selected item is a directory or a file
+				if (file.hasOwnProperty("children"))
+				{
+					menu.addItem((item) => {
+						item.setTitle("New spreadsheet").setIcon("document").onClick(function(){
+						   create_new_file(app, file.path, 0 )
+						});
+					  });
+				}
 			})
 		  );
 

--- a/main.ts
+++ b/main.ts
@@ -58,8 +58,6 @@ export default class SpreadsheetPlugin extends Plugin {
 
 		this.registerEvent(
 			this.app.workspace.on("file-menu", (menu, file) => {
-				// Jaedon's Fix
-				// Check if the selected item is a directory or a file
 				if (file.hasOwnProperty("children"))
 				{
 					menu.addItem((item) => {

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Editor, MarkdownView, Notice, Plugin, WorkspaceLeaf } from 'obsidian';
+import { App, Editor, MarkdownView, Notice, Plugin, TFolder, WorkspaceLeaf } from 'obsidian';
 import { SpreadsheetView, VIEW_TYPE_SPREADSHEET } from "./view"
 
 
@@ -58,7 +58,7 @@ export default class SpreadsheetPlugin extends Plugin {
 
 		this.registerEvent(
 			this.app.workspace.on("file-menu", (menu, file) => {
-				if (file.hasOwnProperty("children")) {
+				if (file instanceof TFolder) {
 					menu.addItem((item) => {
 						item.setTitle("New spreadsheet").setIcon("document").onClick(function(){
 						   create_new_file(app, file.path, 0 )

--- a/main.ts
+++ b/main.ts
@@ -58,13 +58,12 @@ export default class SpreadsheetPlugin extends Plugin {
 
 		this.registerEvent(
 			this.app.workspace.on("file-menu", (menu, file) => {
-				if (file.hasOwnProperty("children"))
-				{
+				if (file.hasOwnProperty("children")) {
 					menu.addItem((item) => {
 						item.setTitle("New spreadsheet").setIcon("document").onClick(function(){
 						   create_new_file(app, file.path, 0 )
 						});
-					  });
+					});
 				}
 			})
 		  );


### PR DESCRIPTION
The context menu would give the option to create a new spreadsheet when a file was selected. This would produce an error if the option was clicked because it would try to create a new spreadsheet using the file name which is not a directory.

I added an if statement that only gives the option when a directory is selected by checking if the "file" object in the event has a "children" property.

*Edit
Now checks using "instanceof TFolder"